### PR TITLE
Fix Gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.1
-  - 2.2
-  - 2.1
-before_install: gem install bundler -v 1.14.4
-bundler_args: --without guard

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # This repository is maintained by: 
-* @rzhade3 @leila-alderman
+* @rzhade3 @maclarel

--- a/hackerone-client.gemspec
+++ b/hackerone-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features|.github|)/})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
-  spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "faraday", ">= 2.0.0"
   spec.add_runtime_dependency "activesupport"
 end

--- a/lib/hackerone/client/version.rb
+++ b/lib/hackerone/client/version.rb
@@ -2,6 +2,6 @@
 
 module Hackerone
   module Client
-    VERSION = "0.22.0"
+    VERSION = "0.22.1"
   end
 end


### PR DESCRIPTION
This PR fixes the Gemspec to add a hard dependency on Faraday `>= 2.0`. This is due to the changes that were merged in https://github.com/github/hackerone-client/pull/2

Supplementary changes to remove extraneous files from the build package and old CI configs were also removed